### PR TITLE
gotta update this to use this library from jupiter-core-rs

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -24,7 +24,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       # Install Cachix
-      - uses: cachix/install-nix-action@v17
+      - uses: cachix/install-nix-action@v22
         with:
           install_url: https://nixos-nix-install-tests.cachix.org/serve/i6laym9jw3wg9mw6ncyrk6gjx4l34vvx/install
           install_options: "--tarball-url-prefix https://nixos-nix-install-tests.cachix.org/serve"

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -31,7 +31,7 @@ jobs:
           extra_nix_config: |
             experimental-features = nix-command flakes
       - name: Setup Cachix
-        uses: cachix/cachix-action@v10
+        uses: cachix/cachix-action@v12
         with:
           name: saber
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -21,7 +21,7 @@ jobs:
           profile: minimal
           toolchain: nightly-2021-12-25
       - name: Cache dependencies
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
 
       # Install Cachix
       - uses: cachix/install-nix-action@v17

--- a/.github/workflows/libraries.yml
+++ b/.github/workflows/libraries.yml
@@ -23,7 +23,7 @@ jobs:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
           components: rustfmt, clippy
       - name: Cache dependencies
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
       - run: cargo doc
 
   test:
@@ -38,5 +38,5 @@ jobs:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
           components: rustfmt, clippy
       - name: Cache dependencies
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
       - run: cargo test --workspace --exclude stable-swap

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -23,7 +23,7 @@ jobs:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
           components: rustfmt, clippy
       - name: Cache dependencies
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
 
       - name: Run cargo fmt
         run: cargo fmt -- --check
@@ -45,5 +45,5 @@ jobs:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
           components: rustfmt, clippy
       - name: Cache dependencies
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
       - run: cargo check

--- a/.github/workflows/program.yml
+++ b/.github/workflows/program.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v3
 
       # Install Cachix
-      - uses: cachix/install-nix-action@v17
+      - uses: cachix/install-nix-action@v22
       - name: Setup Cachix
         uses: cachix/cachix-action@v12
         with:
@@ -78,7 +78,7 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
 
       # Install Cachix
-      - uses: cachix/install-nix-action@v17
+      - uses: cachix/install-nix-action@v22
       - name: Setup Cachix
         uses: cachix/cachix-action@v12
         with:
@@ -139,7 +139,7 @@ jobs:
   ##       uses: Swatinem/rust-cache@v2
 
   ##     # Install Cachix
-  ##     - uses: cachix/install-nix-action@v17
+  ##     - uses: cachix/install-nix-action@v22
   ##     - name: Setup Cachix
   ##       uses: cachix/cachix-action@v12
   ##       with:

--- a/.github/workflows/program.yml
+++ b/.github/workflows/program.yml
@@ -53,7 +53,7 @@ jobs:
           export PATH="/home/runner/.local/share/solana/install/active_release/bin:$PATH"
           solana --version
       - name: Cache Rust
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
         with:
           key: ${{ runner.os }}-${{ env.SOLANA_VERSION }}
 
@@ -112,7 +112,7 @@ jobs:
           profile: minimal
           toolchain: ${{ env.RUST_TOOLCHAIN }}
       - name: Cache Rust
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
         with:
           key: ${{ runner.os }}-${{ env.SOLANA_VERSION }}
 
@@ -136,7 +136,7 @@ jobs:
   ##         profile: minimal
   ##         toolchain: nightly-2022-02-01
   ##     - name: Cache dependencies
-  ##       uses: Swatinem/rust-cache@v1
+  ##       uses: Swatinem/rust-cache@v2
 
   ##     # Install Cachix
   ##     - uses: cachix/install-nix-action@v17

--- a/.github/workflows/program.yml
+++ b/.github/workflows/program.yml
@@ -21,7 +21,7 @@ jobs:
       # Install Cachix
       - uses: cachix/install-nix-action@v17
       - name: Setup Cachix
-        uses: cachix/cachix-action@v10
+        uses: cachix/cachix-action@v12
         with:
           name: saber
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
@@ -80,7 +80,7 @@ jobs:
       # Install Cachix
       - uses: cachix/install-nix-action@v17
       - name: Setup Cachix
-        uses: cachix/cachix-action@v10
+        uses: cachix/cachix-action@v12
         with:
           name: saber
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
@@ -141,7 +141,7 @@ jobs:
   ##     # Install Cachix
   ##     - uses: cachix/install-nix-action@v17
   ##     - name: Setup Cachix
-  ##       uses: cachix/cachix-action@v10
+  ##       uses: cachix/cachix-action@v12
   ##       with:
   ##         name: saber
   ##         authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}

--- a/.github/workflows/program.yml
+++ b/.github/workflows/program.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  SOLANA_VERSION: "1.9.12"
+  SOLANA_VERSION: "1.11.10"
   RUST_TOOLCHAIN: "1.59.0"
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
           override: true
           profile: minimal
           toolchain: ${{ env.RUST_TOOLCHAIN }}
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
       - name: Publish crates
         run: nix shell .#ci --command cargo ws publish --from-git --yes --skip-published --token ${{ secrets.CARGO_PUBLISH_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: cachix/install-nix-action@v17
       - name: Setup Cachix
-        uses: cachix/cachix-action@v10
+        uses: cachix/cachix-action@v12
         with:
           name: saber
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: cachix/install-nix-action@v17
       - name: Setup Cachix
-        uses: cachix/cachix-action@v10
+        uses: cachix/cachix-action@v12
         with:
           name: saber
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     name: Release crate on crates.io
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v17
+      - uses: cachix/install-nix-action@v22
       - name: Setup Cachix
         uses: cachix/cachix-action@v12
         with:
@@ -37,7 +37,7 @@ jobs:
     name: Release verifiable binaries
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v17
+      - uses: cachix/install-nix-action@v22
       - name: Setup Cachix
         uses: cachix/cachix-action@v12
         with:

--- a/Anchor.toml
+++ b/Anchor.toml
@@ -1,5 +1,5 @@
 anchor_version = "0.24.2"
-solana_version = "1.9.12"
+solana_version = "1.11.10"
 
 [workspace]
 members = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1899,9 +1899,9 @@ checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "uint"
-version = "0.9.1"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6470ab50f482bde894a037a57064480a246dbfdd5960bd65a44824693f08da5f"
+checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
 dependencies = [
  "byteorder",
  "crunchy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1842,18 +1842,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.32"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5f6586b7f764adc0231f4c79be7b920e766bb2f3e51b3661cdb263828f19994"
+checksum = "8c1b05ca9d106ba7d2e31a9dab4a64e7be2cce415321966ea3132c49a656e252"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.32"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12bafc5b54507e0149cdf1b145a5d80ab80a90bcd9275df43d4fff68460f6c21"
+checksum = "e8f2591983642de85c921015f3f070c665a197ed69e417af436115e3a1407487"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1813,18 +1813,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.31"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
+checksum = "f5f6586b7f764adc0231f4c79be7b920e766bb2f3e51b3661cdb263828f19994"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.31"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
+checksum = "12bafc5b54507e0149cdf1b145a5d80ab80a90bcd9275df43d4fff68460f6c21"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -457,6 +457,9 @@ name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cfg-if"
@@ -885,6 +888,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
+name = "jobserver"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -913,9 +925,9 @@ checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
 
 [[package]]
 name = "libfuzzer-sys"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "336244aaeab6a12df46480dc585802aa743a72d66b11937844c61bbca84c991d"
+checksum = "ae185684fe19814afd066da15a7cc41e126886c21282934225d9fc847582da58"
 dependencies = [
  "arbitrary",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1725,7 +1725,7 @@ dependencies = [
 
 [[package]]
 name = "stable-swap"
-version = "1.8.1"
+version = "1.8.2"
 dependencies = [
  "solana-program",
  "solana-sdk",
@@ -1736,7 +1736,7 @@ dependencies = [
 
 [[package]]
 name = "stable-swap-anchor"
-version = "1.8.1"
+version = "1.8.2"
 dependencies = [
  "anchor-lang",
  "stable-swap-client",
@@ -1744,7 +1744,7 @@ dependencies = [
 
 [[package]]
 name = "stable-swap-client"
-version = "1.8.1"
+version = "1.8.2"
 dependencies = [
  "arbitrary",
  "arrayref",
@@ -1756,7 +1756,7 @@ dependencies = [
 
 [[package]]
 name = "stable-swap-fuzz"
-version = "1.8.1"
+version = "1.8.2"
 dependencies = [
  "arbitrary",
  "chrono",
@@ -1770,7 +1770,7 @@ dependencies = [
 
 [[package]]
 name = "stable-swap-math"
-version = "1.8.1"
+version = "1.8.2"
 dependencies = [
  "borsh",
  "num-traits",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1842,18 +1842,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.34"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1b05ca9d106ba7d2e31a9dab4a64e7be2cce415321966ea3132c49a656e252"
+checksum = "c53f98874615aea268107765aa1ed8f6116782501d18e53d08b471733bea6c85"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.34"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8f2591983642de85c921015f3f070c665a197ed69e417af436115e3a1407487"
+checksum = "f8b463991b4eab2d801e724172285ec4195c650e8ec79b149e6c2a8e6dd3f783"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,9 +206,9 @@ checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
 
 [[package]]
 name = "arbitrary"
-version = "1.1.0"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c38b6b6b79f671c25e1a3e785b7b82d7562ffc9cd3efdc98627e5668a2472490"
+checksum = "5a7924531f38b1970ff630f03eb20a2fde69db5c590c93b0f3482e95dcc5fd60"
 dependencies = [
  "derive_arbitrary",
 ]
@@ -574,9 +574,9 @@ dependencies = [
 
 [[package]]
 name = "derive_arbitrary"
-version = "1.1.0"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98e23c06c035dac87bd802d98f368df73a7f2cb05a66ffbd1f377e821fac4af9"
+checksum = "c9a577516173adb681466d517d39bd468293bc2c2a16439375ef0f35bba45f3d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,6 +199,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7ed72e1635e121ca3e79420540282af22da58be50de153d36f81ddc6b83aa9e"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -457,10 +466,11 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.20"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6127248204b9aba09a362f6c930ef6a78f2c1b2215f8a7b398c06e1083f17af0"
+checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
 dependencies = [
+ "iana-time-zone",
  "js-sys",
  "num-integer",
  "num-traits",
@@ -494,6 +504,12 @@ name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cpufeatures"
@@ -823,6 +839,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad2bfd338099682614d3ee3fe0cd72e0b6a41ca6a87f6a74a3bd593c91650501"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "js-sys",
+ "wasm-bindgen",
+ "winapi",
+]
+
+[[package]]
 name = "indoc"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -857,9 +886,9 @@ checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "js-sys"
-version = "0.3.57"
+version = "0.3.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "671a26f820db17c2a2750743f1dd03bafd15b98c9f30c7c2628c024c05d73397"
+checksum = "258451ab10b34f8af53416d1fdab72c22e805f0c92a1136d59470ec0b11138b2"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -878,9 +907,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.124"
+version = "0.2.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a41fed9d98f27ab1c6d161da622a4fa35e8a54a8adc24bbf3ddd0ef70b0e50"
+checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -1046,9 +1075,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.10.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
+checksum = "074864da206b4973b84eb91683020dbefd6a8c3f0f38e054d93954e891935e4e"
 
 [[package]]
 name = "opaque-debug"
@@ -1925,9 +1954,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.80"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27370197c907c55e3f1a9fbe26f44e937fe6451368324e009cba39e139dc08ad"
+checksum = "fc7652e3f6c4706c8d9cd54832c4a4ccb9b5336e2c3bd154d5cccfbf1c1f5f7d"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -1935,13 +1964,13 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.80"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e04185bfa3a779273da532f5025e33398409573f348985af9a1cbf3774d3f4"
+checksum = "662cd44805586bd52971b9586b1df85cdbbd9112e4ef4d8f41559c334dc6ac3f"
 dependencies = [
  "bumpalo",
- "lazy_static",
  "log",
+ "once_cell",
  "proc-macro2",
  "quote",
  "syn",
@@ -1950,9 +1979,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.80"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17cae7ff784d7e83a2fe7611cfe766ecf034111b49deb850a3dc7699c08251f5"
+checksum = "b260f13d3012071dfb1512849c033b1925038373aea48ced3012c09df952c602"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1960,9 +1989,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.80"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99ec0dc7a4756fffc231aab1b9f2f578d23cd391390ab27f952ae0c9b3ece20b"
+checksum = "5be8e654bdd9b79216c2929ab90721aa82faf65c48cdf08bdc4e7f51357b80da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1973,9 +2002,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.80"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d554b7f530dee5964d9a9468d95c1f8b8acae4f282807e7d27d4b03099a46744"
+checksum = "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a"
 
 [[package]]
 name = "web-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -457,14 +457,15 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+checksum = "6127248204b9aba09a362f6c930ef6a78f2c1b2215f8a7b398c06e1083f17af0"
 dependencies = [
- "libc",
+ "js-sys",
  "num-integer",
  "num-traits",
  "time",
+ "wasm-bindgen",
  "winapi",
 ]
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -19,7 +19,7 @@ name = "fuzz"
 arbitrary = "1.1.3"
 chrono = "0.4"
 lazy_static = "1.4.0"
-libfuzzer-sys = "0.4.0"
+libfuzzer-sys = "0.4.4"
 rand = "0.8.4"
 solana-program = "^1.9"
 spl-token = { version = "^3", features = ["no-entrypoint"] }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stable-swap-fuzz"
-version = "1.8.1"
+version = "1.8.2"
 authors = ["michaelhly <michaelhly@gmail.com>"]
 edition = "2021"
 description = "Fuzz tests for the Saber StableSwap program."

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -16,7 +16,7 @@ cargo-fuzz = true
 name = "fuzz"
 
 [dependencies]
-arbitrary = "1.0.0"
+arbitrary = "1.1.3"
 chrono = "0.4"
 lazy_static = "1.4.0"
 libfuzzer-sys = "0.4.0"

--- a/stable-swap-anchor/Cargo.toml
+++ b/stable-swap-anchor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stable-swap-anchor"
-version = "1.8.1"
+version = "1.8.2"
 description = "Anchor bindings for the StableSwap Rust client."
 license = "Apache-2.0"
 authors = ["michaelhly <michaelhly@gmail.com>"]

--- a/stable-swap-client/Cargo.toml
+++ b/stable-swap-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stable-swap-client"
-version = "1.8.1"
+version = "1.8.2"
 description = "StableSwap Rust client."
 license = "Apache-2.0"
 authors = ["michaelhly <michaelhly@gmail.com>"]

--- a/stable-swap-client/Cargo.toml
+++ b/stable-swap-client/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["solana", "saber"]
 fuzz = ["arbitrary"]
 
 [dependencies]
-arbitrary = { version = "1.0.2", features = ["derive"], optional = true }
+arbitrary = { version = "1.1.3", features = ["derive"], optional = true }
 arrayref = "0.3.6"
 num-derive = "0.3"
 num-traits = "0.2"

--- a/stable-swap-math/Cargo.toml
+++ b/stable-swap-math/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stable-swap-math"
-version = "1.8.1"
+version = "1.8.2"
 description = "Calculations for the StableSwap invariant"
 license = "Apache-2.0"
 authors = ["michaelhly <michaelhly@gmail.com>"]

--- a/stable-swap-math/Cargo.toml
+++ b/stable-swap-math/Cargo.toml
@@ -13,8 +13,7 @@ keywords = ["solana", "saber", "math"]
 borsh = "0.9.2"
 num-traits = "0.2"
 stable-swap-client = { path = "../stable-swap-client", version = "^1" }
-# This must be pinned to 0.9.1 until Solana's Rust fork supports Rust >=1.56.1
-uint = { version = "=0.9.1", default-features = false }
+uint = { version = "0.9", default-features = false }
 
 [dev-dependencies]
 proptest = "1.0.0"

--- a/stable-swap-program/README.md
+++ b/stable-swap-program/README.md
@@ -11,7 +11,7 @@ _We recommend using the included Nix flake to develop within this repo._
 Download or update the Solana SDK by running:
 
 ```bash
-solana-install init 1.9.12
+solana-install init 1.11.10
 ```
 
 To build the program, run:

--- a/stable-swap-program/program/Cargo.toml
+++ b/stable-swap-program/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stable-swap"
-version = "1.8.1"
+version = "1.8.2"
 authors = ["michaelhly <michaelhly@gmail.com>"]
 edition = "2021"
 description = "Saber StableSwap program."

--- a/stable-swap-program/sdk/yarn.lock
+++ b/stable-swap-program/sdk/yarn.lock
@@ -5353,7 +5353,7 @@ tsconfig-paths@^3.12.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tslib@^1.8.1:
+tslib@^1.8.2:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
@@ -5368,7 +5368,7 @@ tsutils@^3.21.0:
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.21.0.tgz#b48717d394cea6c1e096983eed58e9d61715b623"
   integrity sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==
   dependencies:
-    tslib "^1.8.1"
+    tslib "^1.8.2"
 
 tweetnacl@^1.0.0:
   version "1.0.3"


### PR DESCRIPTION
```
cargo build
    Updating git repository `https://github.com/mercurial-finance/mercurial-dynamic-amm-sdk`
    Updating git repository `https://github.com/mercurial-finance/mercurial_sdk`
    Updating crates.io index
    Updating git repository `https://github.com/mercurial-finance/stable-swap`
    Updating git repository `https://github.com/solana-labs/solana-program-library`
error: failed to select a version for `uint`.
    ... required by package `stable-swap-math v1.8.1 (https://github.com/mercurial-finance/stable-swap?rev=f49a9166fd1b7afd14dded3cdd600fb19b4c6982#f49a9166)`
    ... which satisfies git dependency `meteora-stable-swap-math` of package `mercurial-amm v0.4.9 (https://github.com/mercurial-finance/mercurial-dynamic-amm-sdk?rev=b2cdc9e7d527902f7d5f1bcd2ca76f58c1242fdd#b2cdc9e7)`
    ... which satisfies git dependency `amm` of package `jupiter-crawler v0.1.0 (/data/source/work/jup-ag/jupiter-core-rs/jupiter-crawler)`
versions that meet the requirements `=0.9.1` are: 0.9.1

all possible versions conflict with previously selected packages.

  previously selected package `uint v0.9.5`
    ... which satisfies dependency `uint = "^0.9"` (locked to 0.9.5) of package `jupiter-core v0.1.0 (/data/source/work/jup-ag/jupiter-core-rs/jupiter-core)`
    ... which satisfies path dependency `jupiter-core` (locked to 0.1.0) of package `jupiter-crawler v0.1.0 (/data/source/work/jup-ag/jupiter-core-rs/jupiter-crawler)`

failed to select a version for `uint` which could resolve this conflict
```